### PR TITLE
Readme: WikiMedia→MediaWiki, updated Linux path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # PZ_RadioData_Converter
-Converts Project Zomboid's RadioData.xml file into WikiMedia format.
+Converts Project Zomboid's RadioData.xml file into MediaWiki format.
 
 ## Installation
-
 Download necessary version from [Releases](https://github.com/KBheid/PZ_RadioData_Converter/releases).
 
-Requires Java 8+
+Requires Java 8+.
 
 ## Usage
-
 Open the JAR by double clicking or utilizing `java -jar PZ_RadioDataParser.jar` from the commandline.
 
 Some fields may be prepopulated:
@@ -16,7 +14,7 @@ Some fields may be prepopulated:
 - If the input file field is unset, the input file field will attempt to populate it with a `RadioData.xml` file based in the following locations based on the user's OS:
   - Windows: `C:/Program Files (x86)/Steam/steamapps/common/ProjectZomboid/media/radio`
   - MacOS: `~/Library/Application Support/Steam/steamapps/common/ProjectZomboid/media/radio` 
-  - Other (Linux, likely): `~/.steam/steam/SteamApps/common/ProjectZomboid/media/radio`
+  - Other (Linux, likely): `~/.steam/steam/steamapps/common/ProjectZomboid/projectzomboid/media/radio`
 - The output directory field will be set if a directory named `wiki` is present in the directory that the JAR is present in. 
 
 When both fields are populated, the Parse button should become available. Selecting the Parse button will transform the input `RadioData.xml` file into directories named by the channel type. The files in said directories will be named based on the channel name followed with a `.wiki` extension.
@@ -29,20 +27,20 @@ Changes to output format will likely be made in `Main.java`. Format changes can 
 
 `Channel`s contain `Broadcast`s, which are collections of `Entry`s. 
 
-The properties of these objects are as follows
+The properties of these objects are as follows:
 
 `Channel`:
-- `name` - The name of the channel (eg. PawsTV)
-- `channelType` - The type of the channel (eg. television)
-- `frequency` - The frequency that the channel broadcasts on ingame (eg. 205)
+- `name` - The name of the channel (eg. PawsTV).
+- `channelType` - The type of the channel (eg. television).
+- `frequency` - The frequency that the channel broadcasts on ingame (eg. 205).
 
 `Broadcast`:
 - `startTime` - The start time of the broadcast. The time unit is currently unknown.
 - `endTime` - The end time of the broadcast. Again, the time unit is currently unknown.
-- `day` - The day that the broadcast appears. This may be based on an offset defined outside of RadioData.xml (as some with Day 0 will happen far after day 1)
+- `day` - The day that the broadcast appears. This may be based on an offset defined outside of RadioData.xml (as some with day 0 will happen far after day 1).
 
 `Entry`:
-- `hexColor` - The color in hex layout of the entry's text (eg. #ffc000)
+- `hexColor` - The color in hex layout of the entry's text (eg. #ffc000).
 - `text` - The text of the entry.
 
 ## Contributing


### PR DESCRIPTION
It's MediaWiki syntax, Wikimedia is the foundation, but they are easy to mix up :)

I also corrected the Linux path, as PZ uses subfolder on Linux (and steamapps is written lowerecase, at least in my case, which is quite important on Linux ;)).

Also fixed some style while at it.